### PR TITLE
DBDAART-17625

### DIFF
--- a/taf/DE/DE0001BASE.py
+++ b/taf/DE/DE0001BASE.py
@@ -786,7 +786,7 @@ class DE0001BASE(DE):
                     {DE.unique_claims_ids(self, cltype='FTX')}
                 )
 
-                where submtg_state_cd in ({self.de.state_code})
+                where submtg_state_cd in (select distinct submtg_state_cd from base_{self.de.YEAR}_final0)
                 group by submtg_state_cd, msis_ident_num
             """
         self.de.append(type(self).__name__, z)


### PR DESCRIPTION
[DBDAART-17625](https://jiraent.cms.gov/browse/DBDAART-17625) - Potential bug investigation - FTX dummy records in ADE

## What is this and why are we doing it?
With the cutover to TAF v9.0, [DBDAART-15026](https://jiraent.cms.gov/browse/DBDAART-15026) called for the exclusion of dummy records created from claims, for states not involved in the ADE build. The mechanism by which this took place introduced an unforeseen dependency on the otherwise-unused _state_code_ parameter of the DE_Runner: dummy records pulled from claims would be limited to those listed in _state_code_. This code removes said dependency, and uses the set of unique _submtg_state_cd_ values among non-dummy records in the current build as the list of states from which to retain dummies.

## What are the security implications from this change?
N/A

## How did I test this?
Built test ADE using synthetic BSF containing states 41+42+66, and synthetic claims containing states 42+44+66, with both the old and new DE_Runner. _state_code_ parameter submitted as "'41','44','66'.
Both versions produce ADE with non-dummies from 41+42+66, and dummies from 66.
The old code omits dummies from 42 (like it had been doing with CA), since it is not included in _state_code_, but includes 44.
The updated code includes dummies from 42 but omits 44 (due to the build including BSF non-dummies from 42 but not 44).

## Should there be new or updated documentation for this change? (Be specific.)
Documentation handled in associated JIRA tickets

## PR Checklist
- [x] The JIRA ticket number and a short description is in the subject line
- [x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
